### PR TITLE
Fix the lagging header

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
@@ -215,16 +215,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _animationProperties = compositor.CreatePropertySet();
             }
-
+            
             _previousVerticalScrollOffset = _scrollViewer.VerticalOffset;
+            _headerVisual = ElementCompositionPreview.GetElementVisual((UIElement)TargetListView.Header);
 
             _animationProperties.InsertScalar("OffsetY", 0.0f);
 
             ExpressionAnimation expressionAnimation = compositor.CreateExpressionAnimation($"max(animationProperties.OffsetY - ScrollingProperties.Translation.Y, headerVisual.Size.Y)");
             expressionAnimation.SetReferenceParameter("ScrollingProperties", _scrollProperties);
             expressionAnimation.SetReferenceParameter("animationProperties", _animationProperties);
+            expressionAnimation.SetReferenceParameter("headerVisual", _headerVisual);
 
-            _headerVisual = ElementCompositionPreview.GetElementVisual((UIElement)TargetListView.Header);
 
             if (_headerVisual != null && IsQuickReturnEnabled)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _animationProperties = compositor.CreatePropertySet();
             }
-            
+
             _previousVerticalScrollOffset = _scrollViewer.VerticalOffset;
             _headerVisual = ElementCompositionPreview.GetElementVisual((UIElement)TargetListView.Header);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/QuickReturnHeader/QuickReturnHeader.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             _animationProperties.InsertScalar("OffsetY", 0.0f);
 
-            ExpressionAnimation expressionAnimation = compositor.CreateExpressionAnimation("Floor(animationProperties.OffsetY - ScrollingProperties.Translation.Y)");
+            ExpressionAnimation expressionAnimation = compositor.CreateExpressionAnimation($"max(animationProperties.OffsetY - ScrollingProperties.Translation.Y, headerVisual.Size.Y)");
             expressionAnimation.SetReferenceParameter("ScrollingProperties", _scrollProperties);
             expressionAnimation.SetReferenceParameter("animationProperties", _animationProperties);
 


### PR DESCRIPTION
I slightly modified the expression of the animation. This way two things are fixed:

- the lagging behavior (https://github.com/Microsoft/UWPCommunityToolkit/pull/227#issuecomment-242566069)
- the 'wobbling' header (can be seen by pixel movements in the GIF)